### PR TITLE
Added missing dependency: psutil

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{%- set tag = "1.0.0rc0" -%}
+{%- set tag = "1.0.0rc1" -%}
 {%- set version = tag|replace('-', '_') -%}
 {% set python_min = "3.10" %}
 
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/nk53/stanalyzer/archive/refs/tags/v{{ tag }}.tar.gz
-  sha256: df05c6f03ce63d21bae96f860499823bcc5c0dab6aa8f2bc5c16f1d946130b2e
+  sha256: 46e16e8579278ea010a2087657e47676cd71dd860dab6aa67a4c83ca1b1a9ddf
 
 build:
   number: 0
@@ -40,6 +40,7 @@ requirements:
     - sqlmodel >=0.0.22
     - email-validator >=2.2
     - python-multipart >=0.0.17
+    - psutil >=7.0
     - numpy
   run_constrained:
     - hole2 >=2.3


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Mentioning it here because I failed to properly use a PR for the previous update: `stanalyzer` v1.0.0rc is a release candidate for the features targeted for version 1.0, as described [here](https://charmm-gui.org/?doc=stanalyzer).

The primary updates since the dev release are:
- The web UI now shows useful error messages when form submission fails.
- Release builds now automatically hide unfinished features. Use editable (dev) installation to access broken/unfinished features.
- Additional args added to `sta-server` to control uvicorn.
- `--list` and `--compact` flags to `stanalyzer` show the names of programs in the package's analysis dir
- Fixed all known bugs. Now all that remain are unknown bugs (the worst kind).
- Added favicon so the server log will stop complaining about it being missing.