### PR TITLE
Incorporate several bugfixes

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{%- set tag = "1.0.0rc3" -%}
+{%- set tag = "1.0.0rc4" -%}
 {%- set version = tag|replace('-', '_') -%}
 {% set python_min = "3.10" %}
 
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/nk53/stanalyzer/archive/refs/tags/v{{ tag }}.tar.gz
-  sha256: 598f1df1fa80068c07f92bb903da797055d2512c1d9c935c29c8201c2c256537
+  sha256: 6592ff4c33ff7616928102cf4bb49a6066a21ee3a57f27d6b71b9a877f3978da
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{%- set tag = "1.0.0rc5" -%}
+{%- set tag = "1.0.0rc6" -%}
 {%- set version = tag|replace('-', '_') -%}
 {% set python_min = "3.10" %}
 
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/nk53/stanalyzer/archive/refs/tags/v{{ tag }}.tar.gz
-  sha256: 5bb30ddf0242590471e35ad9727976d3d56b242648bc325d6306322caa83e508
+  sha256: 62d832290f00bd5d6b905374cd19919b9a0c57f70914b933df196896b675f398
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/nk53/stanalyzer/archive/refs/tags/v{{ tag }}.tar.gz
-  sha256: 6592ff4c33ff7616928102cf4bb49a6066a21ee3a57f27d6b71b9a877f3978da
+  sha256: bf278939e1958c79867b9e6fd187b303969731f1a15a102dbc3c3c41f90cd445
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{%- set tag = "1.0.0rc4" -%}
+{%- set tag = "1.0.0rc5" -%}
 {%- set version = tag|replace('-', '_') -%}
 {% set python_min = "3.10" %}
 
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/nk53/stanalyzer/archive/refs/tags/v{{ tag }}.tar.gz
-  sha256: bf278939e1958c79867b9e6fd187b303969731f1a15a102dbc3c3c41f90cd445
+  sha256: 5bb30ddf0242590471e35ad9727976d3d56b242648bc325d6306322caa83e508
 
 build:
   number: 0


### PR DESCRIPTION
- Input files used for testing are now an optional submodule, disabled by default.
- Fixed some broken CLI options.
- Analysis outputs go to their own output directory (separate dir for each analysis program) automatically, unless the desired path is given as an abspath.
- project.json goes in output_dir now.
- `stanalyzer` should run from output_dir