### PR TITLE
QoL updates: nk53/stanalyzer#14 and fix annoying popup behavior.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{%- set tag = "1.0.0rc6" -%}
+{%- set tag = "1.0.0rc7" -%}
 {%- set version = tag|replace('-', '_') -%}
 {% set python_min = "3.10" %}
 
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/nk53/stanalyzer/archive/refs/tags/v{{ tag }}.tar.gz
-  sha256: 62d832290f00bd5d6b905374cd19919b9a0c57f70914b933df196896b675f398
+  sha256: d80b1da00a336779c80da96ed8eef81627f40e4f6587beac6d1353eac2844067
 
 build:
   number: 0
@@ -41,6 +41,7 @@ requirements:
     - email-validator >=2.2
     - python-multipart >=0.0.17
     - psutil >=7.0
+    - bracex >=2.0
     - numpy
   run_constrained:
     - hole2 >=2.3


### PR DESCRIPTION
MNT: Re-rendered with conda-smithy 3.53.3 and conda-forge-pinning 2025.11.27.22.01.22

Other tools:
- conda-build 25.9.0
- rattler-build 0.47.0
- rattler-build-conda-compat 1.4.6

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Changes:
 - New: Brace expansion for trajectory patterns. This allows selecting a specific range of files.
 - Fixed: Clicking outside of the global popup has correctly minimized the popup. However—besides navigating to the bottom of the screen—it would not do anything else. Users expect that clicking on a field will put that field in focus, making this rather unintuitive. The new behavior: clicking outside the popup will perform the same action that would have occurred if the popup hadn't been there.
