### PR TITLE
v1.0.0rc7 -> v1.0.0rc8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{%- set tag = "1.0.0rc7" -%}
+{%- set tag = "1.0.0rc8" -%}
 {%- set version = tag|replace('-', '_') -%}
 {% set python_min = "3.10" %}
 
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/nk53/stanalyzer/archive/refs/tags/v{{ tag }}.tar.gz
-  sha256: d80b1da00a336779c80da96ed8eef81627f40e4f6587beac6d1353eac2844067
+  sha256: dd7d3467172bb4ea4908e75fc095f1708593c4c9c3000310fcfb2a1f634a8ddc
 
 build:
   number: 0


### PR DESCRIPTION
This change fixes a typo that duplicated the -cntmin option for the compressibility_modulus analysis. It now correctly shows -cntmin and -cntmax options.

MNT: Re-rendered with conda-smithy 3.53.3 and conda-forge-pinning 2025.12.01.21.34.22

Other tools:
- conda-build 25.9.0
- rattler-build 0.47.0
- rattler-build-conda-compat 1.4.6

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
