### PR TITLE
Bugfixes (v1.0.0rc9 -> v1.0.0rc10)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{%- set tag = "1.0.0rc9" -%}
+{%- set tag = "1.0.0rc10" -%}
 {%- set version = tag|replace('-', '_') -%}
 {% set python_min = "3.10" %}
 
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/nk53/stanalyzer/archive/refs/tags/v{{ tag }}.tar.gz
-  sha256: f324cb9d52146d9674107c7a27cdaafa21127338c8a465aa99f47f3ff0bd8c24
+  sha256: 9480534fdc6bb7db7c25282328df177fba9224e7bfed381216432c534953d58b
 
 build:
   number: 0


### PR DESCRIPTION
bond_statistics:
    - would fail when reading empty lines between sections
    - also added defaults to lengths/angles/dihedrals output help msg contacts:
    - forgot to remove unused args from parser cov_analysis:
    - fixed issue where corr_matrix_out passed w/ type LazyFile would fail `np.loadtxt` due to being closed.
    - however, I have no idea why the file needs to be re-read, when its contents are already in memory; that line can probably be removed, but I left it in just in case

MNT: Re-rendered with conda-smithy 3.53.3 and conda-forge-pinning 2025.12.12.23.31.02

Other tools:
- conda-build 25.9.0
- rattler-build 0.47.0
- rattler-build-conda-compat 1.4.6

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
